### PR TITLE
updated ci config for custom root

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
-cd ..
 grunt webpack
 npx jambo build

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -4,5 +4,4 @@
 npm install -g npx
 npm install -D @yext/jamboree
 
-cd ..
 npm install

--- a/ci/serve.sh
+++ b/ci/serve.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
-cd ..
 serve -l 8080 &
 grunt watch

--- a/ci/serve_setup.sh
+++ b/ci/serve_setup.sh
@@ -5,7 +5,6 @@ npm install -g serve npx
 npm install -D @yext/jamboree
 
 # Build public
-cd ..
 npm install
 grunt webpack
 npx jambo build

--- a/config.json
+++ b/config.json
@@ -7,11 +7,11 @@
   ],
   "features": [],
   "ci_config": {
-		"build_setup_cmd": "./build_setup.sh",
-		"build_cmd": "./build.sh",
-		"serve_setup_cmd": "./serve_setup.sh",
-		"serve_cmd": "./serve.sh",
-		"rebuild_cmd": "",
-		"output_directories": ["desktop"]
-	}
+    "build_setup_cmd": "./ci/build_setup.sh",
+    "build_cmd": "./ci/build.sh",
+    "serve_setup_cmd": "./ci/serve_setup.sh",
+    "serve_cmd": "./ci/serve.sh",
+    "rebuild_cmd": "",
+    "output_directories": [ "desktop" ]
+  }
 }


### PR DESCRIPTION
spruce is working on removing the dependency on 'src' so we no longer
need to have the ci scripts inside a src folder to circumvent this
requirement as all ci cmds are run relative to the root by default.

TEST=manual

Verified that the ci commands are working from repo root.