### PR TITLE
added install_deps as a required file for deps

### DIFF
--- a/config.json
+++ b/config.json
@@ -17,7 +17,9 @@
     "dependencies": {
       "install_deps_cmd": "./ci/install_deps.sh",
       "required_files": [
-        "package.json"
+        "package.json",
+        "package-lock.json",
+        "ci/install_deps.sh"
       ]
     }
   }


### PR DESCRIPTION
With the new cbd build flow, we don't implicitly copy the ci folder from
the repo to the docker build context in order to make less assumptions
about a repo's structure. Required files can be used instead to indicate
the files required for the install deps cmd for succeed. Currently,
when the template repo was used for a cbd build it resulted in a build
error because install_deps.sh was missing. This PR adds it along with
package-lock.json as a required file for installing deps.