### PR TITLE
Add the locale_config to the template repo.

### DIFF
--- a/config/global_config.json
+++ b/config/global_config.json
@@ -1,10 +1,8 @@
 {
   "sdkVersion": "1.6", // The version of the Answers SDK to use
   // "apiKey": "<REPLACE ME>", // The answers api key found on the experiences page. This will be provided automatically by the Yext CI system
-  "experienceKey": "<REPLACE ME>",
   // "experienceVersion": "<REPLACE ME>", // the Answers Experience version to use for API requests. This will be provided automatically by the Yext CI system
   // "businessId": "<REPLACE ME>", // The business ID of the account. This will be provided automatically by the Yext CI system
-  "locale": "en", // The default locale for searches. Examples: UK: en-GB, Spanish: es, Spain Spanish: es-ES.
   "logo": "", // The link to the logo for open graph meta tag - og:image.
   "favicon": "",
   "googleTagManagerName": "dataLayer", // The name of your Google Tag Manager data layer

--- a/config/locale_config.json
+++ b/config/locale_config.json
@@ -1,0 +1,15 @@
+{
+  "default": "en",
+  "localeConfig": {
+    "en": {
+      // "fallback": [""], // allows you to specify locale fallbacks for this locale
+      // "translationFile": "<filepath>.po", // the filepath for the translation file
+      // "urlOverride": "", // provide an override for the url path for this locale if you want it to be different than specified in the urlFormat object
+      "experienceKey": "<REPLACE ME>" //  the unique key of your search configuration for this locale
+    }
+  },
+  "urlFormat": {
+    "baseLocale": "{locale}/{pageName}.{pageExt}",
+    "default": "{pageName}.{pageExt}"
+  }
+}


### PR DESCRIPTION
This PR adds the locale_config to the template repo. It also
removes placeholders from the global_config for experienceKey
and locale. Note that these changes will only appear for new
repos. Fambo's upgrade command will not apply these changes to
any existing repos.

TEST=manual

Saw the updated global_config and locale_config in a new repo.
Upgraded an existing repo and did not see either change.