### PR TITLE
ci: Add Node max memory flag

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
+export NODE_OPTIONS="--max-old-space-size=1024"
 npx jambo build
 grunt webpack

--- a/ci/serve.sh
+++ b/ci/serve.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
+export NODE_OPTIONS="--max-old-space-size=1024"
 serve -l 8080 desktop/ &
 grunt watch

--- a/ci/serve_setup.sh
+++ b/ci/serve_setup.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
+export NODE_OPTIONS="--max-old-space-size=1024"
 npx jambo build
 grunt webpack


### PR DESCRIPTION
Previously, our Webpack build would take a large amount of memory trying
to minify the HTML files. As a result, the SGS Live Preview would crash with
a memory error and the webpack files would not build. We have since fixed
this memory issue.

We add this flag as a fallback. This flag increases the Node max memory to
1024mb. This value is the amount of memory in the container running the
build (as was suggested by Spruce). It is currently working in the Yext
Answers builds (with no fix in Webpack minifying) and allowing builds to
go through, albeit slowly.

By default, this flag is 512 mb.

J=SLAP-845
TEST=manual

On Yext Answers site, in a branch, add this line to the serve.sh.
1. Create a Preview in SGS
2. Make an arbitrary change after the preview shows (like a
    space in the Gruntfile)
3. Open the Console
4. The build should succeed with no error, especially not (below)
    as we were getting before
```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

Try restarting preview and starting SGS from a fresh webpage
after committing the ci changes.