### PR TITLE
Add the IS_DEVELOPMENT_PREVIEW environment variable.

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 export NODE_OPTIONS="--max-old-space-size=1024"
+export IS_DEVELOPMENT_PREVIEW='false'
+
 npx jambo build
 grunt webpack

--- a/ci/serve.sh
+++ b/ci/serve.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 export NODE_OPTIONS="--max-old-space-size=1024"
+export IS_DEVELOPMENT_PREVIEW='true'
+
 serve -l 8080 desktop/ &
 grunt watch

--- a/ci/serve.sh
+++ b/ci/serve.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 export NODE_OPTIONS="--max-old-space-size=1024"
+
+#This will use development mode while in the Yext code editor. Set to "false" to test the production build.
 export IS_DEVELOPMENT_PREVIEW='true'
 
 serve -l 8080 desktop/ &

--- a/ci/serve_setup.sh
+++ b/ci/serve_setup.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
 export NODE_OPTIONS="--max-old-space-size=1024"
-export IS_DEVELOPMENT_PREVIEW='true'
-
 npx jambo build
 grunt webpack

--- a/ci/serve_setup.sh
+++ b/ci/serve_setup.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 export NODE_OPTIONS="--max-old-space-size=1024"
+export IS_DEVELOPMENT_PREVIEW='true'
+
 npx jambo build
 grunt webpack


### PR DESCRIPTION
This PR adds the environment variable to a few of the CI scripts.
The variable toggles 'development' or 'production' mode in the
Theme's Webpack toolchain. By setting the variable to false, we
ensure the toolchain runs in 'production' mode. If set to true, the
toolchain is run in 'development' mode.

J=SLAP-962
TEST=manual

Ran the modified CI scripts and ensured the assets were generated
in the correct mode in each case.