### PR TITLE
Add the .npmrc file to the repository

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
This PR adds an .npmrc file to the repository. This file configures how `npm` works in the project. The `engine-strict` attribute was enabled in the config file. With this attribute enabled, if the current Node version does not match the Node version required by a dependency, `npm install` will fail. An error message will be shown indicating the package and version mismatch. A minimum required Node version was recently added to Jambo. That change, paired with this, will give users helpful errors in CBD if the container's Node version doesn't work with the Jambo version.

TEST=manual

Cloned this repo and attempted to run the `ci/install_deps.sh` script with Node 10. Saw an error indicating this Node version was incompatible with Jambo v10. I switched to Node 12 and the `ci/install_deps.sh` script worked without issue.