### PR TITLE
Add IS_DEVELOPMENT_PREVIEW to serve_setup.sh

### DIFF
--- a/ci/serve.sh
+++ b/ci/serve.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 export NODE_OPTIONS="--max-old-space-size=1024"
 
-#This will use development mode while in the Yext code editor. Set to "false" to test the production build.
-export IS_DEVELOPMENT_PREVIEW='true'
-
 serve -l 8080 desktop/ &
 grunt watch

--- a/ci/serve.sh
+++ b/ci/serve.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 export NODE_OPTIONS="--max-old-space-size=1024"
 
+#This will use development mode while in the Yext code editor. Set to "false" to test the production build.
+export IS_DEVELOPMENT_PREVIEW='true'
+
 serve -l 8080 desktop/ &
 grunt watch

--- a/ci/serve_setup.sh
+++ b/ci/serve_setup.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 export NODE_OPTIONS="--max-old-space-size=1024"
+export IS_DEVELOPMENT_PREVIEW='true'
 npx jambo build
 grunt webpack

--- a/ci/serve_setup.sh
+++ b/ci/serve_setup.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 export NODE_OPTIONS="--max-old-space-size=1024"
+
+#This will use development mode while in the Yext code editor. Set to "false" to test the production build.
 export IS_DEVELOPMENT_PREVIEW='true'
+
 npx jambo build
 grunt webpack


### PR DESCRIPTION
In serve_setup.sh, we were missing `export IS_DEVELOPMENT_PREVIEW='true'`. This caused the initial preview of an `initializeManually: true` site to not invoke `AnswersExperience.init()`.