### PR TITLE
Upgrade Semgrep action to use ubuntu-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   semgrep:
     name: semgrep/ci
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN_VACCINE_ANSWERS_JAMBO_TEMPLATE_ONLY }}
     container:


### PR DESCRIPTION
Ubuntu 20.04 for Github Actions is being deprecated and will be fully unsupported on 2025-04-01. Update our semgrep action to the latest version.